### PR TITLE
Update To Correctly Follow Vanilla Minecraft Naming Convention For Fields (Powered by Clash of Clangs - WHEELCHAIR METHOD ♿♿♿♿♿♿♿♿♿♿♿♿♿♿♿ wheelchair symbol)

### DIFF
--- a/src/core/bedrock/entity/components/state_vector_component.hpp
+++ b/src/core/bedrock/entity/components/state_vector_component.hpp
@@ -4,8 +4,8 @@
 
 namespace selaura::bedrock {
 	struct StateVectorComponent {
-		Vec3 pos;
-		Vec3 pos_prev;
-		Vec3 pos_gamdelta;
+		Vec3 mPos;
+		Vec3 mPosPrev;
+		Vec3 mPosDelta;
 	};
 };


### PR DESCRIPTION
![watermark](https://github.com/user-attachments/assets/ce3a8b98-6aef-4bee-984f-56e4ab226b21)
